### PR TITLE
CheckboxList - unnecessary use of Kdyby namespace

### DIFF
--- a/libs/Kdyby/Forms/Controls/CheckboxList.php
+++ b/libs/Kdyby/Forms/Controls/CheckboxList.php
@@ -10,7 +10,6 @@
 
 namespace Kdyby\Forms\Controls;
 
-use Kdyby;
 use Nette\Forms\Container;
 use Nette;
 use Nette\Utils\Html;


### PR DESCRIPTION
use Kdyby; and no Kdyby classes in code
